### PR TITLE
Replaces reference to "examplemod"

### DIFF
--- a/src/main/resources/pack.mcmeta
+++ b/src/main/resources/pack.mcmeta
@@ -1,6 +1,6 @@
 {
     "pack": {
-        "description": "examplemod resources",
+        "description": "moecraft resources",
         "pack_format": 5,
         "_comment": "A pack_format of 5 requires json lang files and some texture changes from 1.15. Note: we require v5 pack meta for all mods."
     }


### PR DESCRIPTION
I found another reference to examplemod and replaced it with moecraft